### PR TITLE
fixing first time loading geohash responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.11] - 2015-07-11
+### Fixed
+* A bug with requesting geohash the first time a dataset is seen, now responding with 202
+
 ## [0.2.11] - 2015-06-06
 ### Added
 * Needed to add a couple headers to the geohash response when caches are expired.
@@ -248,6 +252,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 2014-08-25
   * working on tests
 
+[0.2.12]: https://github.com/Esri/koop/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/Esri/koop/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/Esri/koop/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/Esri/koop/compare/v0.2.8...v0.2.9

--- a/controller/index.js
+++ b/controller/index.js
@@ -936,6 +936,8 @@ var Controller = function( agol, BaseController ){
           if (exists) {
             // send back the geohash, but send fileInfo to set the expired header
             controller.returnGeohash(req, res, path, fileInfo);
+          } else {
+            res.status( 202 ).json( { status: 'processing' } );
           }
           // re-direct to findItemData since we need to cache the data
           req.params.silent = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-agol",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "An ArcGIS Online wrapper for koop",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The first time a geohash is requested, if the data are not already cached, koop was not resonding at all. On second requests it was fine. This fixes that. 