### PR TITLE
Worker error catching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased 
+### Fixed
+* A bug with workers where json containing NaN in response JSON was choking the json parsing. Now they get replaced with `null`.
+### Added 
+* Wrapped workers functions in a domain to try to force clean exits on any unhandled errors
+* Added a new route for accessing geohashes from `.../item/FeatureServer/0/geohash`.
+
 ## [0.2.12] - 2015-07-11
 ### Fixed
 * A bug with requesting geohash the first time a dataset is seen, now responding with 202

--- a/controller/index.js
+++ b/controller/index.js
@@ -556,6 +556,12 @@ var Controller = function( agol, BaseController ){
   };
 
   controller.featureserver = function( req, res ){
+    // check for geohash route and redirect
+    if (req.params.method && req.params.method === 'geohash'){
+      controller.getGeohash(req, res);
+      return;
+    }
+
     var self = this;
     var callback = req.query.callback;
     delete req.query.callback;

--- a/models/agol.js
+++ b/models/agol.js
@@ -57,9 +57,11 @@ var AGOL = function( koop ){
   /**
    * Adds a service to the Cache
    * needs a host, generates an id 
+   *
    * @param {string} id - the id used to reference this host in the db
    * @param {string} host - host to request items from
    * @param {function} callback - The callback.
+   * TODO dont call koop.Cache.db directly
    */
   agol.register = function (id, host, callback) {
     var type = 'agol:services';

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,5 +18,6 @@ module.exports = {
   'get /agol/:id/:item/:layer/tiles/:z/:x/:y.:format': 'tiles',
   'get /agol/:id/:item/:layer/tiles/:z/:x/:y': 'tiles',
   'get /agol/:id/:item/tiles/:z/:x/:y.:format': 'servicetiles',
-  'get /agol/:id/:item/tiles/:z/:x/:y': 'servicetiles'
+  'get /agol/:id/:item/tiles/:z/:x/:y': 'servicetiles',
+  'get /agol/:id/:item/FeatureServer/:layer/geohash': 'getGeohash',
 };

--- a/workers/request-worker.js
+++ b/workers/request-worker.js
@@ -16,15 +16,12 @@ var protocols = {
   https: https
 };
 
-//require('look').start();
-
 // Init Koop with things it needs like a log and Cache 
 koop.log = new koop.Logger( config );
 koop.Cache = new koop.DataCache( koop );
 
 // registers a DB modules  
 koop.Cache.db = pgcache.connect( config.db.conn, koop );
-
 
 // Create the job queue for this worker process
 // connects to the redis same redis
@@ -61,14 +58,21 @@ process.once( 'SIGINT', function ( sig ) {
 });
 
 jobs.process('agol', function(job, done){
-  makeRequest(job, done);
+  var domain = require('domain').create();
+  domain.on('error', function(err){
+    done(err);
+  });
+
+  domain.run(function(){
+    makeRequest(job, done);
+  });
 });
 
 
 setInterval(function () {
-    if (typeof gc === 'function') {
-        gc();
-    }
+  if (typeof gc === 'function') {
+    gc();
+  }
 }, 5000);
 
 


### PR DESCRIPTION
adds a few things to workers to address some failing jobs using gzip deflating and adds a "domain" to ensure each job exits cleanly with an error. 

Also adds a new geohash route on the featureservice endpoint so that we can access a geohash from within a feature service layer implementation.  